### PR TITLE
Automated Merge main into 2.x.x (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 <!--- changelog for features or fixes can be written here according to convention above - this will be compiled into a release section through CI/CD when publishing a release --->
 ## Unreleased
 
+## [2.5.0] - 2023-11-22
+### Added
+- Verify issue with flow 3 ([#99](https://github.com/MoneyLion/de-python-util/pull/99))
+
+## [2.4.0] - 2023-11-17
+### Added
+- Verify issue with flow 2 ([#99](https://github.com/MoneyLion/de-python-util/pull/99))
+
 ## [2.3.0] - 2023-11-17
 ### Added
 - Verify issue with flow ([#99](https://github.com/MoneyLion/de-python-util/pull/99))
@@ -46,3 +54,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [2.1.0]: https://github.com/jeremytee97/multi-branching-poc/releases/tag/2.1.0
 [2.2.0]: https://github.com/jeremytee97/multi-branching-poc/releases/tag/2.2.0
 [2.3.0]: https://github.com/jeremytee97/multi-branching-poc/releases/tag/2.3.0
+[2.4.0]: https://github.com/jeremytee97/multi-branching-poc/releases/tag/2.4.0
+[2.5.0]: https://github.com/jeremytee97/multi-branching-poc/releases/tag/2.5.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     # package setup
-    version="2.3.0",
+    version="2.5.0",
     # requirements
     python_requires=">=3.11",
     classifiers=[


### PR DESCRIPTION
* feat: Add update workflow

This commit adds an update workflow to the codebase. It addresses issue #99 and can be found in the Unreleased section of the CHANGELOG.md file.

* Release 2.1.0 (#4)



* Generate Change Log, Bump Version, Tag and Release, Merge main to Target Branch Generate Change Log and Bump Version

Renamed the workflow file from "cut_off.yml" to "generate_change_log_bump_version.yml". Updated the name of the workflow from "Prepare Release" to "Generate Change Log and Bump Version". Renamed the job from "Create release" to "generate-change-log-bump-version". Also, renamed another workflow file from "release_preparation.yml" to "merge_to_target_branch.yml". Updated the name of this workflow from "Create Pull Request For Release" to "Merge main to Target Branch". Finally, updated the name of a third workflow file from "release.yaml" to "Tag and Release".

[Generated by AI]

* chore: update changelog to trigger test

* Release 2.2.0 (#6)



* chore: update changelog

* Release 2.3.0 (#8)



* Update CHANGELOG.md

* Release 2.4.0

* chore: update changelog

* Release 2.5.0 (#13)



---------